### PR TITLE
#3 Proposal to print rai version

### DIFF
--- a/rai/main.go
+++ b/rai/main.go
@@ -293,7 +293,7 @@ func addCommands(root *cobra.Command) {
 }
 
 func main() {
-	var root = &cobra.Command{Use: "rai"}
+	var root = &cobra.Command{Use: "rai", Version: version}
 	// todo: additional root options
 	// --request-timeout
 	// --token : Bearer token for authenticating API request

--- a/rai/version_current.go
+++ b/rai/version_current.go
@@ -1,0 +1,18 @@
+// Copyright 2022 RelationalAI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Represents the current rai's CLI version
+var version = "0.1.1-alpha"


### PR DESCRIPTION
This approach is simple and leverage [Cobra's built-in support for version print](https://pkg.go.dev/github.com/spf13/cobra#Command.Version).

The `version` variable could be overwrited - at compile time - using `-ldflags="-X 'main.version=x.x.x-xxxx'"`.