### PR TITLE
Revert the Go SDK back to v0.1, to use v1 transactions for Execute()! Disable auto-updating dependencies.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/relationalai/rai-sdk-go v0.0.0-20220601014253-d82e4af6a549
+	github.com/relationalai/rai-sdk-go v0.1.0
 	github.com/spf13/cobra v1.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/relationalai/rai-sdk-go v0.1.0
+	github.com/relationalai/rai-sdk-go v0.1.1
 	github.com/spf13/cobra v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/relationalai/rai-sdk-go v0.0.0-20220601014253-d82e4af6a549 h1:xkD1SNoF01SiFXZ3AZohPkDNrmFG5Xe/3HcCE4QV7iw=
-github.com/relationalai/rai-sdk-go v0.0.0-20220601014253-d82e4af6a549/go.mod h1:iRrtfB7eNVhlfkWrooRC/AJZiwULGmJI9klvdL2lGKg=
+github.com/relationalai/rai-sdk-go v0.1.0 h1:SQNSgdrZufAsjkLJ+hYPKylasojUkqWTQsGcC+dtfKg=
+github.com/relationalai/rai-sdk-go v0.1.0/go.mod h1:iRrtfB7eNVhlfkWrooRC/AJZiwULGmJI9klvdL2lGKg=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/relationalai/rai-sdk-go v0.1.0 h1:SQNSgdrZufAsjkLJ+hYPKylasojUkqWTQsGcC+dtfKg=
-github.com/relationalai/rai-sdk-go v0.1.0/go.mod h1:iRrtfB7eNVhlfkWrooRC/AJZiwULGmJI9klvdL2lGKg=
+github.com/relationalai/rai-sdk-go v0.1.1 h1:QSokvvKTM5i/RQFw8WPKWxjnI39SkdI35HSfCvt/la8=
+github.com/relationalai/rai-sdk-go v0.1.1/go.mod h1:iRrtfB7eNVhlfkWrooRC/AJZiwULGmJI9klvdL2lGKg=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/tidy
+++ b/tidy
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export GOPRIVATE="github.com/relationalai/*"
-go get -u ./rai/...
+go get ./rai/...
 go mod tidy -compat=1.17


### PR DESCRIPTION
[Prevent ./tidy script from updating dependencies](https://github.com/RelationalAI/rai-cli/commit/0c53744fa7afc6b0a225080c6b5fe800938dbbed) 

This was picking up even breaking changes from the rai-sdk-go, since
the `-u` flag indiscriminantly upgrades MINOR releases, so it would
change e.g. `v0.1.0` to `v0.2.0`, even though that is a breaking change.

[Set SDK to rai-sdk-go v0.1.1](https://github.com/RelationalAI/rai-cli/commit/d395e3595b3cb0b6c56498bccee5512acca0a8aa)