### PR TITLE
Use path prefix as default prefix when loading models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 ## main
-
 * Add --prefix option to load-models
 * Add get-model-source command
+* Use models path as a default prefix (could be overwitten by --prefix flag)
 
 ## V0.1.1
 

--- a/rai/cmds.go
+++ b/rai/cmds.go
@@ -528,11 +528,16 @@ func loadModels(cmd *cobra.Command, args []string) {
 	prefix := action.getString("prefix")
 	models := map[string]io.Reader{}
 	for _, arg := range args[1:] {
+		if !(cmd.Flags().Lookup("prefix").Changed) {
+			prefix, _ = filepath.Split(arg)
+		}
+
 		name := filepath.Join(prefix, baseSansExt(arg))
 		r, err := os.Open(arg)
 		if err != nil {
 			fatal(err.Error())
 		}
+
 		models[name] = r
 	}
 	if engine == "" {


### PR DESCRIPTION
This PR adds the ability to the `cli` to use models paths as prefix by default like explained below:
* Default behavior
```
rai load-models DB_NAME --engine ENGINE_NAME path1/to/model1.rel path2/to/model2.rel
```
Models will be loaded under `path1/to/model1` and `path2/to/model2` prefixes.
* Override default behavior by specifying `--prefix`
```
rai load-models DB_NAME --engine ENGINE_NAME path1/to/model1.rel path2/to/model2.rel --prefix ""
```
Models will be loaded under `model1` and `model2`