### PR TITLE
Build rai binaries on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,6 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: "https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz"
-        build_command: "go build -o build/rai rai/*"
+        project_path: "./rai"
         binary_name: "rai"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
         exclude:
           - goarch: "386"
             goos: darwin
-          - goarch: arm64
-            goos: windows
     steps:
     - uses: actions/checkout@v3
     - uses: wangyoucao577/go-release-action@v1.32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release rai-cli binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: ["386", amd64]
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.32
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz"
+        build_command: "go build -o build/rai rai/*"
+        binary_name: "rai"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: ["386", amd64]
-
+        exclude:
+          - goarch: "386"
+            goos: darwin
+          - goarch: arm64
+            goos: windows
     steps:
     - uses: actions/checkout@v3
     - uses: wangyoucao577/go-release-action@v1.32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       matrix:
         goos: [linux, darwin, windows]
-        goarch: ["386", amd64]
+        goarch: ["386", amd64, arm64]
         exclude:
           - goarch: "386"
             goos: darwin
+          - goarch: arm64
+            goos: windows
     steps:
     - uses: actions/checkout@v3
     - uses: wangyoucao577/go-release-action@v1.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## main
+## v0.1.2
 
 * Add list-edb-names command
 * Add --prefix option to load-models
 * Add get-model-source command
-
+* Add prebuilt binaries on release
 ## V0.1.1
 
 ## v0.1.0


### PR DESCRIPTION
This PR adds a github workflow to build `rai-cli` binaries for `linux`, `macos` and `windows` and source them under release 
Closes: https://github.com/RelationalAI/rai-cli/issues/33